### PR TITLE
Fix SendSplitPackage skipping a byte between the 1st and 2nd package

### DIFF
--- a/src/se/bitcraze/crazyfliecontrol/ble/BleLink.java
+++ b/src/se/bitcraze/crazyfliecontrol/ble/BleLink.java
@@ -414,7 +414,7 @@ public class BleLink extends CrtpDriver {
         // controlbyte + payload (rest)
         byte[] secondPacket = new byte[20];
         secondPacket[0] = new ControlByte(false, pid, 0).toByte();
-        System.arraycopy(packet.getPayload(),19, secondPacket, 1, packet.getPayload().length-19);
+        System.arraycopy(packet.getPayload(),18 , secondPacket, 1, packet.getPayload().length-19);
         // send second packet
         mContext.runOnUiThread(new SendBlePacket(secondPacket, mCrtpUpChar));
         pid = (pid+1)%4;


### PR DESCRIPTION
Split package sends bytes with index 0 to 17 in the first package (line 410). In the second package, it starts with index 19 of the payload, losing the byte with index 18 entirely and resulting in incomplete payload at arrival. Changed line 417 to make the 2nd package start at index 18 instead of 19, so the entire payload is included.